### PR TITLE
:recycle: Refactor entrypoint and create a new entrypoint with params

### DIFF
--- a/plugins/components/collider/Collider.cpp
+++ b/plugins/components/collider/Collider.cpp
@@ -9,10 +9,16 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-char const *componentName = "Collider";
+char const *const componentName = "Collider";
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint(float width, float height)
+Components::IComponent *buildDefault()
+{
+    return new Components::Collider();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(float width, float height)
 {
     return new Components::Collider(width, height);
 }

--- a/plugins/components/controllable/Controllable.cpp
+++ b/plugins/components/controllable/Controllable.cpp
@@ -9,9 +9,15 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint()
+Components::IComponent *buildDefault()
 {
     return new Components::Controllable();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(std::unordered_map<enum Action, enum Key> &keyBindings)
+{
+    return new Components::Controllable(keyBindings);
 }
 
 LIBRARY_ENTRYPOINT

--- a/plugins/components/health/Health.cpp
+++ b/plugins/components/health/Health.cpp
@@ -9,12 +9,18 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-char const *componentName = "Health";
+char const *const componentName = "Health";
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint()
+Components::IComponent *buildDefault()
 {
     return new Components::Health();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(uint32_t currentHealth, uint32_t maxHealth)
+{
+    return new Components::Health(currentHealth, maxHealth);
 }
 
 LIBRARY_ENTRYPOINT

--- a/plugins/components/position/Position.cpp
+++ b/plugins/components/position/Position.cpp
@@ -9,7 +9,13 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint(uint32_t x, uint32_t y, uint32_t layer)
+Components::IComponent *buildDefault()
+{
+    return new Components::Position();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(uint32_t x, uint32_t y, uint32_t layer)
 {
     return new Components::Position(x, y, layer);
 }
@@ -21,4 +27,4 @@ Components::IComponent *entryConfig(libconfig::Setting &config)
 }
 
 LIBRARY_ENTRYPOINT
-char const *componentName = "Position";
+char const *const componentName = "Position";

--- a/plugins/components/velocity/Velocity.cpp
+++ b/plugins/components/velocity/Velocity.cpp
@@ -9,7 +9,13 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint(uint32_t x, uint32_t y)
+Components::IComponent *buildDefault()
+{
+    return new Components::Velocity();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(uint32_t x, uint32_t y)
 {
     return new Components::Velocity(x, y);
 }
@@ -21,4 +27,4 @@ Components::IComponent *entryConfig(libconfig::Setting &config)
 }
 
 LIBRARY_ENTRYPOINT
-char const *componentName = "Velocity";
+char const *const componentName = "Velocity";

--- a/plugins/components/velocity/Velocity.hpp
+++ b/plugins/components/velocity/Velocity.hpp
@@ -28,16 +28,20 @@ namespace Components {
      */
     class Velocity : public AComponent<Velocity> {
     public:
+
         /**
-         * @brief Default constructor for the Velocity component.
+         * @brief Constructor using configuration setting.
          * 
-         * Initializes the velocity components (x and y) to zero.
+         * Initializes the velocity with the x and y components from the configuration settings.
+         * 
+         * @param config The configuration settings to use for the component.
          */
-        Velocity() : AComponent("Velocity"), x(0), y(0) {};
         Velocity(libconfig::Setting &config) : AComponent("Velocity")
         {
-            config.lookupValue("x", x);
-            config.lookupValue("y", y);
+            if (!config.lookupValue("x", x))
+                x = 0;
+            if (!config.lookupValue("y", y))
+                y = 0;
         }
 
         /**
@@ -48,7 +52,7 @@ namespace Components {
          * @param x The X component of the velocity.
          * @param y The Y component of the velocity.
          */
-        Velocity(uint32_t x, uint32_t y) : AComponent("Velocity"), x(x), y(y) {};
+        Velocity(uint32_t x = 0, uint32_t y = 0) : AComponent("Velocity"), x(x), y(y) {};
 
         /**
          * @brief Default destructor for the Velocity component.

--- a/plugins/components/visible/Visible.cpp
+++ b/plugins/components/visible/Visible.cpp
@@ -9,12 +9,18 @@
 #include "library_entrypoint.hpp"
 
 LIBRARY_ENTRYPOINT
-char const *componentName = "Visible";
+char const *const componentName = "Visible";
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *entryPoint()
+Components::IComponent *buildDefault()
 {
     return new Components::Visible();
+}
+
+LIBRARY_ENTRYPOINT
+Components::IComponent *buildWithParams(bool isVisible)
+{
+    return new Components::Visible(isVisible);
 }
 
 LIBRARY_ENTRYPOINT

--- a/plugins/components/visible/Visible.hpp
+++ b/plugins/components/visible/Visible.hpp
@@ -53,7 +53,7 @@ public:
      */
     Visible(libconfig::Setting &config) : AComponent(std::string("Visible")) {
         if (!config.lookupValue("isVisible", isVisible))
-            throw std::runtime_error("Missing 'isVisible' setting for Visible component");
+            isVisible = false;
     }
 
     /**

--- a/plugins/systems/config/Config.cpp
+++ b/plugins/systems/config/Config.cpp
@@ -195,7 +195,6 @@ void Systems::ConfigLoader::extractConfig(libconfig::Setting &root, Engine::Game
 LIBRARY_ENTRYPOINT
 Systems::ISystem *entryPoint(const char *configFilePath)
 {
-    std::cout << "entryPoint called with configFilePath: " << configFilePath << std::endl;
     return new Systems::ConfigLoader(configFilePath);
 }
 

--- a/src/DLLoader/DLLoader.hpp
+++ b/src/DLLoader/DLLoader.hpp
@@ -84,7 +84,7 @@ class DLLoader {
         * @tparam T The type of the object to create.
         * @tparam Args The types of the arguments to pass to the function.
         *
-        * @param entryPointName The name of the function to retrieve from the library (default: "entryPoint").
+        * @param entryPointName The name of the function to retrieve from the library (default: "buildDefault").
         * @param args The arguments to pass to the function.
         *
         * @return A pointer to a new instance of type T.
@@ -92,7 +92,7 @@ class DLLoader {
         * @throw DLLExceptions If the function pointer cannot be retrieved.
         */
         template<typename T, typename... Args>
-        std::unique_ptr<T> getUniqueInstance(const std::string &entryPointName = "entryPoint", Args&&... args) {
+        std::unique_ptr<T> getUniqueInstance(const std::string &entryPointName = "buildDefault", Args&&... args) {
             return std::unique_ptr<T>(callFunction<T *, Args...>(entryPointName, args...));
         };
 

--- a/src/GameEngine/GameEngine.hpp
+++ b/src/GameEngine/GameEngine.hpp
@@ -60,7 +60,7 @@ namespace Engine {
 
                 std::cout << "Component ID: " << componentID << " registered!" << std::endl;
 
-                auto compCtor = loader.getFunctionPointer<Component *>("entryPoint");
+                auto compCtor = loader.getFunctionPointer<Component *>("buildDefault");
 
                 __components.emplace(typeIndex, std::unique_ptr<Component>(compCtor()));
                 __idStringToType.emplace(std::move(componentID), typeIndex);
@@ -124,7 +124,7 @@ namespace Engine {
                     throw std::runtime_error("Component type not registered");
 
                 DLLoader &loader = __componentLoaders.at(typeIndex);
-                auto componentInstance = loader.getUniqueInstance<Component>("entryPoint", std::forward<Args>(args)...);
+                auto componentInstance = loader.getUniqueInstance<Component>("buildWithParams", std::forward<Args>(args)...);
 
                 if (!componentInstance)
                     throw std::runtime_error("Failed to load component from shared object");


### PR DESCRIPTION
Instead of having one entryPoint that takes either args or no args, we decided it would be better to have two entryPoints.

One : 'buildDefault' would have 0 args and the other : 'buildWithParams' could take any args it wants containing all args we want to pass through.
We keep the 'entryConfig' entryPoint as its used and doesnt need to be changed yet.