### PR TITLE
:recycle: Check & Fix components

### DIFF
--- a/config/config.cfg
+++ b/config/config.cfg
@@ -31,6 +31,33 @@ entities = (
                     ACTION2 = "RIGHT_CLICK",
                     ACTION5 = "SPACE"
                 }
+            },
+            {
+                name = "Health",
+                args = {
+                    maxVal = 100,
+                    currentVal = 100
+                }
+            },
+            {
+                name = "Collider",
+                args = {
+                    width = 30,
+                    height = 30
+                }
+            },
+            {
+                name = "Velocity",
+                args = {
+                    x = 1,
+                    y = 0
+                }
+            },
+            {
+                name = "Visible",
+                args = {
+                    isVisible = false
+                }
             }
         )
     },

--- a/plugins/components/AComponent.hpp
+++ b/plugins/components/AComponent.hpp
@@ -53,6 +53,14 @@ namespace Components {
                 return *reinterpret_cast<SparseArray<IComponent> *>(sparseArray);
             }
 
+            /**
+             * @class BadSparseArrayCast
+             * 
+             * @brief Exception thrown when a SparseArray cast fails.
+             * 
+             * This exception is thrown when a SparseArray cast fails.
+             * It is a subclass of std::bad_any_cast.
+             */
             class BadSparseArrayCast : public std::bad_any_cast {
                 char const *what() const noexcept override {
                     return std::bad_any_cast::what();

--- a/plugins/components/collider/Collider.cpp
+++ b/plugins/components/collider/Collider.cpp
@@ -18,7 +18,7 @@ Components::IComponent *buildDefault()
 }
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *buildWithParams(float width, float height)
+Components::IComponent *buildWithParams(uint32_t width, uint32_t height)
 {
     return new Components::Collider(width, height);
 }

--- a/plugins/components/collider/Collider.hpp
+++ b/plugins/components/collider/Collider.hpp
@@ -22,7 +22,12 @@
     #include <libconfig.h++>
 
 namespace Components {
-
+    /**
+     * @brief Collider component class in Components.
+     * 
+     * This class represents a rectangle collider for an entity, storing the width and height of the collider.
+     * It provides methods to serialize and deserialize the collider data for network transmission or storage.
+     */
     class Collider : public AComponent<Collider> {
     public:
         /**

--- a/plugins/components/collider/Collider.hpp
+++ b/plugins/components/collider/Collider.hpp
@@ -10,6 +10,12 @@
 
     #include "plugins/components/AComponent.hpp"
     #include "GameEngine/GameEngine.hpp"
+    #ifdef _WIN32
+        #include <windows.h>
+        #pragma comment(lib, "ws2_32.lib")
+    #else
+        #include <arpa/inet.h>
+    #endif
     #include <vector>
     #include <stdexcept>
     #include <cstdint>
@@ -24,7 +30,7 @@ namespace Components {
          * 
          * Initializes the rectangle collider with default width and height of 0.
          */
-        Collider(float width = 1.0f, float height = 1.0f) : AComponent(std::string("Collider")), width(width), height(height) {};
+        Collider(uint32_t width = 1, uint32_t height = 1) : AComponent(std::string("Collider")), width(width), height(height) {};
 
         /**
          * @brief Constructor using configuration.
@@ -34,10 +40,10 @@ namespace Components {
          */
         Collider(libconfig::Setting &config) : AComponent(std::string("Collider")) {
             if (!config.lookupValue("width", width)) {
-                width = 1.0f;
+                width = 1;
             }
             if (!config.lookupValue("height", height)) {
-                height = 1.0f;
+                height = 1;
             }
         }        
 
@@ -49,11 +55,10 @@ namespace Components {
          * @return std::vector<uint8_t> Serialized data.
          */
         std::vector<uint8_t> serialize() override {
-            std::vector<uint8_t> data;
-            appendToData(data, width);
-            appendToData(data, height);
-            return data;
-        };
+            __network.width = htonl(width);
+            __network.height = htonl(height);
+            return std::vector<uint8_t>(__data, __data + sizeof(__data));
+        }
 
         /**
          * @brief Deserialize the collider data
@@ -64,12 +69,18 @@ namespace Components {
          * @throws std::runtime_error If the data size is invalid.
          */
         void deserialize(std::vector<uint8_t> &data) override {
-            if (data.size() != getConstantSize())
+            if (data.size() != getSize())
                 throw std::runtime_error("Invalid data size for Collider component");
 
-            width = *reinterpret_cast<float *>(&data[0]);
-            height = *reinterpret_cast<float *>(&data[sizeof(float)]);
-        };
+            uint32_t widthBits = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
+            uint32_t heightBits = (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | data[7];
+
+            widthBits = ntohl(widthBits);
+            heightBits = ntohl(heightBits);
+
+            width = *reinterpret_cast<uint32_t *>(&widthBits);
+            height = *reinterpret_cast<uint32_t *>(&heightBits);
+        }
 
         /**
          * @brief Get the fixed size of the serialized data
@@ -77,7 +88,7 @@ namespace Components {
          * @return size_t Size in bytes
          */
         size_t getSize() const override {
-            return getConstantSize();
+            return sizeof(__data);
         }
 
         /**
@@ -93,8 +104,8 @@ namespace Components {
             if (args.size() != 2)
                 throw std::runtime_error("Invalid number of arguments for Collider component");
 
-            float width = std::any_cast<float>(args[0]);
-            float height = std::any_cast<float>(args[1]);
+            uint32_t width = std::any_cast<uint32_t>(args[0]);
+            uint32_t height = std::any_cast<uint32_t>(args[1]);
 
             auto collider = engine.newComponent<Components::Collider>(width, height);
             engine.getRegistry().componentManager().addComponent<Components::Collider>(to, std::move(collider));
@@ -108,47 +119,36 @@ namespace Components {
          * @param config The configuration setting to extract the component data from.
          */
         void addTo(ECS::Entity &to, Engine::GameEngine &engine, libconfig::Setting &config) override {
-        float width = 0.0f;
-        float height = 0.0f;
+            int width = 0, height = 0; 
 
-        if (!config.lookupValue("width", width)) {
-            std::cerr << "Warning: 'width' not found in config. Using default value: 1.0f\n";
-            width = 1.0f;
+            if (!config.lookupValue("width", width)) {
+                std::cerr << "Warning: 'width' not found in config. Using default value: 1\n";
+                width = 1;
+            }
+
+            if (!config.lookupValue("height", height)) {
+                std::cerr << "Warning: 'height' not found in config. Using default value: 1\n";
+                height = 1;
+            }
+
+            std::cout << "width: " << width << " height: " << height << std::endl;
+
+            std::unique_ptr<Components::Collider> collider = engine.newComponent<Components::Collider>(static_cast<uint32_t>(width), static_cast<uint32_t>(height));
+            engine.getRegistry().componentManager().addComponent<Components::Collider>(to, std::move(collider));
+            std::cout << std::endl;
         }
-        
-        if (!config.lookupValue("height", height)) {
-            std::cerr << "Warning: 'height' not found in config. Using default value: 1.0f\n";
-            height = 1.0f;
-        }
-        std::unique_ptr<Components::Collider> collider = engine.newComponent<Components::Collider>(width, height);
-        engine.getRegistry().componentManager().addComponent<Components::Collider>(to, std::move(collider));
-    }
 
-
-        float width;
-        float height;
-        char const *componentName;
+        uint32_t width;
+        uint32_t height;
 
     private:
-        /**
-         * @brief Returns the constant size of the serialized data.
-         * 
-         * @return size_t The fixed size of the serialized Collider data.
-         */
-        size_t getConstantSize() const {
-            return 2 * sizeof(float);
-        }
-        
-        /**
-         * @brief Helper function to append a float value to a byte vector.
-         * 
-         * @param data The byte vector to append to.
-         * @param value The float value to append.
-         */
-        void appendToData(std::vector<uint8_t> &data, float value) {
-            auto bytes = reinterpret_cast<uint8_t *>(&value);
-            data.insert(data.end(), bytes, bytes + sizeof(float));
-        }
+        union {
+            struct {
+                uint32_t width;
+                uint32_t height;
+            } __network;
+            uint8_t __data[8];
+        };
     };
 };
 

--- a/plugins/components/collider/Collider.hpp
+++ b/plugins/components/collider/Collider.hpp
@@ -77,14 +77,8 @@ namespace Components {
             if (data.size() != getSize())
                 throw std::runtime_error("Invalid data size for Collider component");
 
-            uint32_t widthBits = (data[0] << 24) | (data[1] << 16) | (data[2] << 8) | data[3];
-            uint32_t heightBits = (data[4] << 24) | (data[5] << 16) | (data[6] << 8) | data[7];
-
-            widthBits = ntohl(widthBits);
-            heightBits = ntohl(heightBits);
-
-            width = *reinterpret_cast<uint32_t *>(&widthBits);
-            height = *reinterpret_cast<uint32_t *>(&heightBits);
+            width = ntohl(*reinterpret_cast<uint32_t *>(data.data()));
+            height = ntohl(*reinterpret_cast<uint32_t *>(data.data() + 4));
         }
 
         /**

--- a/plugins/components/health/Health.hpp
+++ b/plugins/components/health/Health.hpp
@@ -37,7 +37,8 @@ namespace Components {
          * 
          * Initializes current and max health to default values of 100.
          */
-        Health(uint32_t currentHealth = 100, uint32_t maxHealth = 100) : AComponent(std::string("Health")) {}
+        Health(uint32_t currentHealth = 100, uint32_t maxHealth = 100) :
+            AComponent(std::string("Health")), currentHealth(currentHealth), maxHealth(maxHealth) {};
 
         /**
          * @brief Constructs a Health component with values from the configuration.
@@ -56,8 +57,7 @@ namespace Components {
                 currentHealth = 100;
             if (!config.lookupValue("maxHealth", maxHealth))
                 maxHealth = 100;
-        }
-
+        };
 
         /**
          * @brief Serializes the health values into a byte vector.
@@ -140,8 +140,12 @@ namespace Components {
                 std::cerr << "Warning: 'maxVal' not found in config. Using default value: 1.0f\n";
                 maxVal = 100;
             }
+
+            std::cout << "currentVal: " << currentVal << " maxVal: " << maxVal << std::endl;
+
             std::unique_ptr<Components::Health> health = engine.newComponent<Components::Health>(static_cast<uint32_t>(currentVal), static_cast<uint32_t>(maxVal));
             engine.getRegistry().componentManager().addComponent<Components::Health>(to, std::move(health));
+            std::cout << std::endl;
         };
 
         uint32_t currentHealth;

--- a/plugins/components/position/Position.hpp
+++ b/plugins/components/position/Position.hpp
@@ -39,9 +39,9 @@ namespace Components {
         Position() : AComponent("Position"), x(0), y(0), layer(0) {};
         Position(libconfig::Setting &config) : AComponent("Position")
         {
-            config.lookupValue("x", x);
-            config.lookupValue("y", y);
-            config.lookupValue("layer", layer);
+            if (!config.lookupValue("x", x)) x = 0;
+            if (!config.lookupValue("y", y)) y = 0;
+            if (!config.lookupValue("layer", layer)) layer = 1;
         }
 
         /**
@@ -126,13 +126,21 @@ namespace Components {
          * @note The configuration setting should contain the keys 'x', 'y', and 'layer'.
          */
         void addTo(ECS::Entity &to, Engine::GameEngine &engine, libconfig::Setting &config) override {
-            int xVal = 0, yVal = 0, layerVal = 0;
+            int xVal = 0, yVal = 0, layerVal = 1;
 
-            if (
-                !config.lookupValue("x", xVal) ||
-                !config.lookupValue("y", yVal) ||
-                !config.lookupValue("layer", layerVal)) {
-                throw std::invalid_argument("Failed to retrieve values for 'x', 'y', or 'layer'");
+            if (!config.lookupValue("x", xVal)) {
+                std::cerr << "Warning: 'x' not found in config. Using default value: 0\n";
+                xVal = 0;
+            }
+
+            if (!config.lookupValue("y", yVal)) {
+                std::cerr << "Warning: 'y' not found in config. Using default value: 0\n";
+                yVal = 0;
+            }
+
+            if (!config.lookupValue("layer", layerVal)) {
+                std::cerr << "Warning: 'layer' not found in config. Using default value: 1\n";
+                layerVal = 1;
             }
 
             std::cout << "x: " << xVal << " y: " << yVal << " layer: " << layerVal << std::endl;

--- a/plugins/components/visible/Visible.cpp
+++ b/plugins/components/visible/Visible.cpp
@@ -18,9 +18,9 @@ Components::IComponent *buildDefault()
 }
 
 LIBRARY_ENTRYPOINT
-Components::IComponent *buildWithParams(bool isVisible)
+Components::IComponent *buildWithParams(uint8_t isVisible)
 {
-    return new Components::Visible(isVisible);
+    return new Components::Visible(!!isVisible);
 }
 
 LIBRARY_ENTRYPOINT

--- a/plugins/components/visible/Visible.hpp
+++ b/plugins/components/visible/Visible.hpp
@@ -65,7 +65,7 @@ public:
      * @return A vector of bytes representing the serialized visibility state.
      */
     std::vector<uint8_t> serialize() override {
-        return { static_cast<uint8_t>(isVisible) };
+        return { (isVisible ? (uint8_t)1 : (uint8_t)0) };
     }
 
     /**
@@ -93,7 +93,7 @@ public:
      * @return The size of the serialized component, in bytes.
      */
     size_t getSize() const override {
-        return (sizeof(__data));
+        return 1;
     }
 
     /**
@@ -133,7 +133,7 @@ public:
 
         std::cout << "isVisible: " << isVisibleConfig << std::endl;
 
-        std::unique_ptr<Components::Visible> visibilityComponent = engine.newComponent<Components::Visible>(isVisibleConfig);
+        std::unique_ptr<Components::Visible> visibilityComponent = engine.newComponent<Components::Visible>(static_cast<uint8_t>(isVisibleConfig));
         engine.getRegistry().componentManager().addComponent<Components::Visible>(to, std::move(visibilityComponent));
         std::cout << std::endl;
     }
@@ -142,18 +142,7 @@ public:
      * @brief Indicates whether the entity is visible or not.
      */
     bool isVisible;
-    char const *componentName;
 
-private:
-    /**
-     * @brief Network packet representation for the Visible component.
-     */
-    union {
-        struct {
-            uint8_t isVisible;
-        } __network;
-        uint8_t __data[1];
-    };
 };
 
 }; // namespace Components

--- a/plugins/components/visible/Visible.hpp
+++ b/plugins/components/visible/Visible.hpp
@@ -111,7 +111,7 @@ public:
             throw std::runtime_error("Invalid number of arguments for Visible component");
         
         bool visibility = std::any_cast<bool>(args[0]);
-        engine.getRegistry().componentManager().addComponent<Components::Visible>(to, engine.newComponent<Components::Visible>(visibility));
+        engine.getRegistry().componentManager().addComponent<Components::Visible>(to, engine.newComponent<Components::Visible>(static_cast<uint8_t>(visibility)));
     }
 
     /**

--- a/src/server/Main.cpp
+++ b/src/server/Main.cpp
@@ -12,31 +12,13 @@
 #include "plugins/components/position/Position.hpp"
 #include "plugins/components/velocity/Velocity.hpp"
 #include "plugins/components/controllable/Controllable.hpp"
+#include "plugins/components/visible/Visible.hpp"
+#include "plugins/components/health/Health.hpp"
+#include "plugins/components/collider/Collider.hpp"
 #include <exception>
 #include <iostream>
 #include <typeindex>
 #include <vector>
-
-void displayComponents(ECS::Registry &reg)
-{
-    SparseArray<Components::Position> &positionComponents = reg.componentManager().getComponents<Components::Position>();
-    SparseArray<Components::Velocity> &velocityComponents = reg.componentManager().getComponents<Components::Velocity>();
-
-    std::cout << "Displaying components: " << std::endl;
-    std::cout << "\nPosition components: \n" << std::endl;
-    for (std::unique_ptr<Components::Position> &pos : positionComponents) {
-        if (!pos)
-            continue;
-        std::cout << "Position: " << pos->x << ", " << pos->y << std::endl;
-    }
-
-    std::cout << "\nVelocity components: \n" << std::endl;
-    for (std::unique_ptr<Components::Velocity> &vel : velocityComponents) {
-        if (!vel)
-            continue;
-        std::cout << "Velocity: " << vel->x << ", " << vel->y << std::endl;
-    }
-}
 
 template<typename It>
 void displayPolymorphic(Engine::GameEngine &engine, It begin, It end)
@@ -46,7 +28,7 @@ void displayPolymorphic(Engine::GameEngine &engine, It begin, It end)
     for (auto it = begin; it != end; ++it) {
         std::type_index &idx = *it;
 
-        std::cout << "For type index {" << idx.name() << "}:" << std::endl;
+        std::cout << "For type index {" << idx.name() << "}:\n" << std::endl;
 
         auto &dummyComp = engine.getComponentFromId(idx);
 
@@ -60,19 +42,27 @@ void displayPolymorphic(Engine::GameEngine &engine, It begin, It end)
             for (const auto &byte : comp->serialize()) {
                 if (i != 0)
                     std::cout << ", ";
-                std::cout << (int)byte;
+                std::cout << (unsigned)byte;
                 i++;
             }
             std::cout << "}" << std::endl;
         }
+        std::cout << std::endl;
     }
 }
 
 void updateComponent(size_t id, std::string name, std::vector<uint8_t> data)
 {
     std::cout << "Updating component: " << name << " with ID: " << id << std::endl;
-    for (auto u : data)
-        std::cout << u << " ";
+    std::cout << "    {";
+    int i = 0;
+    for (const auto &byte : data) {
+        if (i != 0)
+            std::cout << ", ";
+        std::cout << (unsigned)byte;
+        i++;
+    }
+    std::cout << "}" << std::endl;
 }
 
 int main() {
@@ -83,11 +73,17 @@ int main() {
     std::vector<std::type_index> types = {
         typeid(Components::Velocity),
         typeid(Components::Position),
-        typeid(Components::Controllable)
+        typeid(Components::Controllable),
+        typeid(Components::Visible),
+        typeid(Components::Health),
+        typeid(Components::Collider)
     };
 
     try {
         engine.registerComponent<Components::Controllable>("./plugins/bin/components/", "Controllable");
+        engine.registerComponent<Components::Visible>("./plugins/bin/components/", "Visible");
+        engine.registerComponent<Components::Health>("./plugins/bin/components/", "Health");
+        engine.registerComponent<Components::Collider>("./plugins/bin/components/", "Collider");
         engine.loadSystems("./plugins/bin/systems/configSystems.cfg");
 
         std::unique_ptr<Components::Position> position = engine.newComponent<Components::Position>(10, 20, 1);
@@ -95,8 +91,6 @@ int main() {
 
         reg.componentManager().addComponent<Components::Position>(entity, std::move(position));
         reg.componentManager().addComponent<Components::Velocity>(entity, std::move(velocity));
-
-        displayComponents(reg);
 
         displayPolymorphic(engine, types.begin(), types.end());
 


### PR DESCRIPTION
Fixed all components from tiny mistakes and wrong implementations.

Major changes : 
``Collider`` component now takes `uint32_t` values instead of floats.
``Visible`` component is casted to a `uint8_t` when sent to the network and casted back to a bool inside the class.

Added docs to lacking classes.