### PR TITLE
:recycle: Fix controllable component

### DIFF
--- a/plugins/components/controllable/Controllable.hpp
+++ b/plugins/components/controllable/Controllable.hpp
@@ -73,9 +73,7 @@ namespace Components {
             AComponent("Controllable"),
             inputs{false},
             actions{false},
-            keyBindings(keyBindings) {
-                std::cerr << "Controllable default ctor:" << std::endl;
-            };
+            keyBindings(keyBindings) {};
 
         /**
          * @brief Constructor with configuration settings.
@@ -104,8 +102,6 @@ namespace Components {
             })
         {
             std::string forward, backward, left, right;
-
-            std::cerr << "Controllable config:" << std::endl;
 
             if (!config.lookupValue("FORWARD", forward)) forward = "Z";
             if (!config.lookupValue("BACKWARD", backward)) backward = "S";
@@ -140,6 +136,7 @@ namespace Components {
          * @brief Serializes the input states into a byte vector.
          * 
          * Converts the inputs (movement directions and actions) into network byte order for transmission or storage.
+         * Also converts the key bindings into network byte order.
          * 
          * @return A vector of bytes representing the serialized input states.
          */
@@ -166,6 +163,7 @@ namespace Components {
          * @brief Deserializes the input states from the provided byte vector.
          * 
          * Reads the inputs (forward, backward, left, right) and actions in network byte order.
+         * Also read the key bindings for each actions.
          * 
          * @param data A vector of bytes representing the serialized input states.
          * @throws std::runtime_error If the data size is invalid.
@@ -187,8 +185,10 @@ namespace Components {
          * @brief Gets the size of the serialized data.
          * 
          * @return The size of the data, in bytes.
+         * 
+         * @note the size is equal to the size of the network array plus the number of key bindings rows.
          */
-        size_t getSize() const override { return 28; };
+        size_t getSize() const override { return sizeof(__data) + keyBindings.size() / 2; };
 
         /**
          * @brief Adds the Controllable component to an entity.

--- a/plugins/components/controllable/Controllable.hpp
+++ b/plugins/components/controllable/Controllable.hpp
@@ -188,7 +188,7 @@ namespace Components {
          * 
          * @note the size is equal to the size of the network array plus the number of key bindings rows.
          */
-        size_t getSize() const override { return sizeof(__data) + keyBindings.size() / 2; };
+        size_t getSize() const override { return sizeof(__data) + keyBindings.size(); };
 
         /**
          * @brief Adds the Controllable component to an entity.

--- a/src/utils/Keys.hpp
+++ b/src/utils/Keys.hpp
@@ -36,7 +36,8 @@ const std::unordered_map<std::string, Key> strToKey = {
     {"NUM_0", Key::NUM_0}, {"NUM_1", Key::NUM_1}, {"NUM_2", Key::NUM_2}, {"NUM_3", Key::NUM_3},
     {"NUM_4", Key::NUM_4}, {"NUM_5", Key::NUM_5}, {"NUM_6", Key::NUM_6}, {"NUM_7", Key::NUM_7},
     {"NUM_8", Key::NUM_8}, {"NUM_9", Key::NUM_9},
-    {"LEFT_CLICK", Key::LEFT_CLICK}, {"RIGHT_CLICK", Key::RIGHT_CLICK}, {"MIDDLE_CLICK", Key::MIDDLE_CLICK}
+    {"LEFT_CLICK", Key::LEFT_CLICK}, {"RIGHT_CLICK", Key::RIGHT_CLICK}, {"MIDDLE_CLICK", Key::MIDDLE_CLICK},
+    {"UNKNOWN", Key::UNKNOWN}
 };
 
 /**


### PR DESCRIPTION
Fixed controllable component serialization not sending infos about the keyMap thus not initializing the component correctly.

Also fixed a small case in the enum Key func : strToKey where Key::UNKNOWN was forgotten