### PR TITLE
:adhesive_bandage: Fix crash at random time

### DIFF
--- a/src/client/Main.cpp
+++ b/src/client/Main.cpp
@@ -31,6 +31,7 @@ int main()
     Engine::GameEngine engine(
         [&conn](size_t id, std::string name, std::vector<uint8_t> data) { conn.sendUpdateComponent(id, name, data); }
     );
+    Chrono chrono;
 
     engine.loadSystems("./src/client/configClient.cfg");
     // Hard coded register for now
@@ -61,7 +62,12 @@ int main()
     {
         // Check that you have the same components here with the map in RTypeClient
         while (conn.gameEnd != true) {
+            if (chrono.getElapsedTime() < 17)
+                continue;
+            conn.lockMutex();
             engine.runSystems();
+            conn.unlockMutex();
+            chrono.restart();
         }
     }
     catch(const std::exception& e)

--- a/src/network/RTypeClient.hpp
+++ b/src/network/RTypeClient.hpp
@@ -9,6 +9,7 @@
     #define RTYPE_CLIENT_HPP_
 
     #include <unordered_map>
+    #include <mutex>
     #include "UDPConnection.hpp"
     #include "GameEngine/GameEngine.hpp"
 
@@ -171,6 +172,22 @@ class RTypeClient : public UDPConnection
          */
         std::unordered_map<uint8_t, std::string> &getCompNames() { return _compNames; };
 
+        /**
+         * @brief Lock _engineMutex
+         * 
+         * @note This function has to be called whenever there are modifications made to the engine
+         * 
+         * @note This function is a blocking call until the mutex is unlocked
+         */
+        void lockMutex();
+
+        /**
+         * @brief Unlock _engineMutex
+         * 
+         * @note Be sure that the mutex is locked beforehand
+         */
+        void unlockMutex();
+
         boost::asio::io_context &getIoContext() { return _io_context; }
 
     public:
@@ -181,6 +198,7 @@ class RTypeClient : public UDPConnection
         std::unordered_map<uint32_t, size_t> _entitiesNetworkId;
         std::vector<uint8_t> _recv_buffer;
         udp::endpoint _sender_endpoint;
+        std::mutex _engineMutex;
 };
 
 #endif /* !RTYPE_CLIENT_HPP_ */

--- a/src/network/UDPServer.cpp
+++ b/src/network/UDPServer.cpp
@@ -44,7 +44,7 @@ void UDPServer::start_receive(Engine::GameEngine &engine) {
                             << ":" << remote_endpoint_.port() << std::endl;
                 client_responses[remote_endpoint_] = true;
                 is_disconnected[remote_endpoint_] = false;
-                checking_client(remote_endpoint_);
+                // checking_client(remote_endpoint_);
                 send_components_infos();
             }
         } else {


### PR DESCRIPTION
This pull requests fixes the crash that was happening at random.

The crash was due to the main thread and the network thread accessing the game engine at the same time and invalidating iterators that then went out-of-bounds.